### PR TITLE
feat: enhance transaction preparation and error handling

### DIFF
--- a/src/cli/lib/cli.ts
+++ b/src/cli/lib/cli.ts
@@ -33,6 +33,9 @@ import {
   DiscoveredTimelockOp,
   DiscoveryWatermarks,
   calculateExpectedEta,
+  prepareRetryableStage,
+  prepareL2ToL1MessageStage,
+  getStageData,
 } from "../../index";
 import { withScope } from "../../utils/logger";
 
@@ -110,9 +113,6 @@ export function createSigner(privateKey: string): ethers.Wallet {
 // Transaction Execution
 // ============================================================================
 
-const RETRYABLE_MAX_RETRIES = 10;
-const RETRYABLE_RETRY_DELAY_MS = 5000;
-
 export async function executeTransaction(
   prepared: PreparedTransaction,
   signer: ethers.Wallet,
@@ -120,57 +120,47 @@ export async function executeTransaction(
 ): Promise<{ success: boolean; txHash?: string; error?: string }> {
   const isRetryable = prepared.description?.toLowerCase().includes("retryable") ?? false;
 
-  for (let attempt = 1; attempt <= (isRetryable ? RETRYABLE_MAX_RETRIES : 1); attempt++) {
-    try {
-      const provider =
-        prepared.chain === "L1"
-          ? providers.l1Provider
-          : prepared.chain === "NOVA"
-            ? providers.novaProvider
-            : providers.l2Provider;
+  try {
+    const provider =
+      prepared.chain === "L1"
+        ? providers.l1Provider
+        : prepared.chain === "NOVA"
+          ? providers.novaProvider
+          : providers.l2Provider;
 
-      const connectedSigner = signer.connect(provider);
+    const connectedSigner = signer.connect(provider);
 
-      console.log(`\nExecuting on ${prepared.chain}: ${prepared.description}`);
-      console.log(`  To: ${prepared.to}`);
-      if (prepared.value !== "0") console.log(`  Value: ${prepared.value}`);
+    console.log(`\nExecuting on ${prepared.chain}: ${prepared.description}`);
+    console.log(`  To: ${prepared.to}`);
+    if (prepared.value !== "0") console.log(`  Value: ${prepared.value}`);
 
-      const tx = await connectedSigner.sendTransaction({
-        to: prepared.to,
-        data: prepared.data,
-        value: prepared.value,
-      });
+    const tx = await connectedSigner.sendTransaction({
+      to: prepared.to,
+      data: prepared.data,
+      value: prepared.value,
+    });
 
-      console.log(`  Tx sent: ${tx.hash}`);
-      const receipt = await tx.wait();
-      console.log(`  Confirmed in block ${receipt.blockNumber}`);
+    console.log(`  Tx sent: ${tx.hash}`);
+    const receipt = await tx.wait();
+    console.log(`  Confirmed in block ${receipt.blockNumber}`);
 
-      return { success: true, txHash: tx.hash };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+    return { success: true, txHash: tx.hash };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
 
-      // For retryables, check if already redeemed
-      if (
-        isRetryable &&
-        (message.includes("REDEEMED") ||
-          message.includes("already redeemed") ||
-          message.includes("NoTicketWithID"))
-      ) {
-        console.log(`  Retryable already redeemed, treating as success`);
-        return { success: true };
-      }
-
-      if (!isRetryable || attempt >= RETRYABLE_MAX_RETRIES) {
-        return { success: false, error: message };
-      }
-
-      console.log(`  Retry ${attempt}/${RETRYABLE_MAX_RETRIES} failed: ${message}`);
-      console.log(`  Retrying in ${RETRYABLE_RETRY_DELAY_MS / 1000}s...`);
-      await new Promise((resolve) => setTimeout(resolve, RETRYABLE_RETRY_DELAY_MS));
+    // For retryables, check if already redeemed
+    if (
+      isRetryable &&
+      (message.includes("REDEEMED") ||
+        message.includes("already redeemed") ||
+        message.includes("NoTicketWithID"))
+    ) {
+      console.log(`  Retryable already redeemed, treating as success`);
+      return { success: true };
     }
-  }
 
-  return { success: false, error: "Unexpected retry loop exit" };
+    return { success: false, error: message };
+  }
 }
 
 // ============================================================================
@@ -196,6 +186,36 @@ export function formatDryRun(prepared: PreparedTransaction): string {
     );
   }
 
+  return lines.join("\n");
+}
+
+/**
+ * Format multiple prepared transactions for display
+ */
+export function formatMultiplePreparedTransactions(
+  preparedTransactions: PreparedTransaction[]
+): string {
+  if (preparedTransactions.length === 0) return "";
+  if (preparedTransactions.length === 1) return formatDryRun(preparedTransactions[0]);
+
+  const lines: string[] = [];
+  for (let i = 0; i < preparedTransactions.length; i++) {
+    const prepared = preparedTransactions[i];
+    lines.push(`[DRY RUN ${i + 1}/${preparedTransactions.length}] ${prepared.description}`);
+    lines.push(`  Chain: ${prepared.chain}`);
+    lines.push(`  To: ${prepared.to}`);
+    if (prepared.operationId) lines.push(`  OperationId: ${prepared.operationId}`);
+    if (prepared.value !== "0") lines.push(`  Value: ${prepared.value}`);
+    lines.push(`  Data: ${prepared.data}`);
+    if (prepared.hashValidation) {
+      lines.push(
+        prepared.hashValidation.isValid
+          ? `  Hash Valid: YES`
+          : `  WARNING: Hash validation failed - ${prepared.hashValidation.error}`
+      );
+    }
+    if (i < preparedTransactions.length - 1) lines.push(""); // Blank line between transactions
+  }
   return lines.join("\n");
 }
 
@@ -402,7 +422,8 @@ export async function runWithLoop(
 export interface TrackCallbackResult {
   key: string;
   result: TrackingResult | null;
-  prepared?: PreparedTransaction;
+  prepared?: PreparedTransaction; // Legacy: first prepared transaction (deprecated)
+  preparedTransactions?: PreparedTransaction[]; // All prepared transactions
   error?: string;
 }
 
@@ -412,7 +433,7 @@ export interface TrackCallbackReturn {
 
 export interface MonitorRunOptions {
   prepare?: boolean;
-  force?: boolean;
+  prepareCompleted?: boolean;
   preparePending?: boolean;
   onTrack?: (result: TrackCallbackResult) => Promise<TrackCallbackReturn | void> | void;
   startBlock?: number;
@@ -444,24 +465,85 @@ const PREPARABLE_STAGE_TYPES = [
 async function prepareStagesForResult(
   tracker: ProposalStageTracker,
   stages: TrackedStage[],
-  options: { prepare?: boolean; force?: boolean; preparePending?: boolean }
-): Promise<{ prepared?: PreparedTransaction; preparations: PrepareResult[]; count: number }> {
+  options: { prepare?: boolean; prepareCompleted?: boolean; preparePending?: boolean },
+  providers: ProviderBundle
+): Promise<{
+  prepared?: PreparedTransaction;
+  preparedTransactions: PreparedTransaction[];
+  preparations: PrepareResult[];
+  count: number;
+}> {
   const preparations: PrepareResult[] = [];
+  const preparedTransactions: PreparedTransaction[] = [];
   let prepared: PreparedTransaction | undefined;
   let count = 0;
 
-  if (!options.prepare) return { preparations, count };
+  if (!options.prepare) return { preparations, preparedTransactions, count };
 
-  if (options.force) {
+  /**
+   * Helper to prepare a stage and handle bulk results for RETRYABLE_EXECUTED and L2_TO_L1_MESSAGE
+   */
+  async function prepareSingleStage(stage: TrackedStage, prepOpts: { prepareCompleted?: boolean }) {
+    // For retryable and L2→L1 message stages, use bulk prepare to get all transactions
+    if (stage.type === "RETRYABLE_EXECUTED") {
+      const retryableData = getStageData(stage, "RETRYABLE_EXECUTED");
+      const targetChains = retryableData?.targetChains;
+      if (!targetChains || targetChains.length === 0) {
+        preparations.push({ success: false, error: "No target chains found" });
+        return;
+      }
+
+      // Prepare retryables for each target chain (can be both Arb1 and Nova)
+      for (const targetChain of targetChains) {
+        const targetProvider =
+          targetChain === "Nova" ? providers.novaProvider : providers.l2Provider;
+        const { results } = await prepareRetryableStage(
+          stage,
+          providers.l1Provider,
+          targetProvider,
+          prepOpts
+        );
+        preparations.push(...results);
+        for (const result of results) {
+          if (result.success) {
+            count++;
+            preparedTransactions.push(result.prepared);
+            if (!prepared) prepared = result.prepared;
+          }
+        }
+      }
+    } else if (stage.type === "L2_TO_L1_MESSAGE") {
+      const { results } = await prepareL2ToL1MessageStage(
+        stage,
+        providers.l2Provider,
+        providers.l1Provider,
+        prepOpts
+      );
+      preparations.push(...results);
+      for (const result of results) {
+        if (result.success) {
+          count++;
+          preparedTransactions.push(result.prepared);
+          if (!prepared) prepared = result.prepared;
+        }
+      }
+    } else {
+      // For other stages, use the tracker's prepareTransaction
+      const prepResult = await tracker.prepareTransaction(stage, prepOpts);
+      preparations.push(prepResult);
+      if (prepResult.success) {
+        count++;
+        preparedTransactions.push(prepResult.prepared);
+        prepared = prepResult.prepared;
+      }
+    }
+  }
+
+  if (options.prepareCompleted) {
     // Historical validation: prepare COMPLETED timelock stages
     for (const stage of stages) {
       if (stage.status === "COMPLETED" && isTimelockStage(stage.type)) {
-        const prepResult = await tracker.prepareTransaction(stage, { force: true });
-        preparations.push(prepResult);
-        if (prepResult.success) {
-          count++;
-          prepared = prepResult.prepared;
-        }
+        await prepareSingleStage(stage, { prepareCompleted: true });
       }
     }
   } else if (options.preparePending) {
@@ -469,28 +551,18 @@ async function prepareStagesForResult(
     for (const stage of stages) {
       const isPreparable = (PREPARABLE_STAGE_TYPES as readonly string[]).includes(stage.type);
       if (isPreparable && stage.status === "PENDING") {
-        const prepResult = await tracker.prepareTransaction(stage, { force: true });
-        preparations.push(prepResult);
-        if (prepResult.success) {
-          count++;
-          prepared = prepResult.prepared;
-        }
+        await prepareSingleStage(stage, { prepareCompleted: true });
       }
     }
   } else {
     // Normal: prepare only READY stages
     const ready = findExecutableStage(stages);
     if (ready) {
-      const prepResult = await tracker.prepareTransaction(ready, {});
-      preparations.push(prepResult);
-      if (prepResult.success) {
-        count++;
-        prepared = prepResult.prepared;
-      }
+      await prepareSingleStage(ready, {});
     }
   }
 
-  return { prepared, preparations, count };
+  return { prepared, preparedTransactions, preparations, count };
 }
 
 // ============================================================================
@@ -509,7 +581,7 @@ function shortScope(key: string): string {
 
 export async function runMonitorCycle(
   tracker: ProposalStageTracker,
-  l2Provider: ethers.providers.Provider,
+  providers: ProviderBundle,
   options: MonitorRunOptions = {}
 ): Promise<{
   result: MonitorRunResult;
@@ -517,6 +589,7 @@ export async function runMonitorCycle(
   timelockOps: DiscoveredTimelockOp[];
   watermarks: DiscoveryWatermarks;
 }> {
+  const l2Provider = providers.l2Provider;
   const tipBlock = await l2Provider.getBlockNumber();
   const blockLag = options.blockLag ?? DEFAULT_BLOCK_LAG;
   const currentBlock = Math.max(0, tipBlock - blockLag);
@@ -556,13 +629,19 @@ export async function runMonitorCycle(
           trackedOperationIds.add(trackResult.timelockLink.operationId.toLowerCase());
         }
 
-        const prepResult = await prepareStagesForResult(tracker, trackResult.stages, options);
+        const prepResult = await prepareStagesForResult(
+          tracker,
+          trackResult.stages,
+          options,
+          providers
+        );
         result.prepared += prepResult.count;
 
         const callbackResult = await options.onTrack?.({
           key,
           result: trackResult,
           prepared: prepResult.prepared,
+          preparedTransactions: prepResult.preparedTransactions,
         });
 
         if (callbackResult?.shouldRetrack) {
@@ -705,15 +784,22 @@ export async function runMonitorCycle(
 export async function trackAndPrepare(
   tracker: ProposalStageTracker,
   txHash: string,
-  options: { prepare?: boolean; force?: boolean; preparePending?: boolean } = {}
-): Promise<{ results: TrackingResult[]; preparations: PrepareResult[] }> {
+  options: { prepare?: boolean; prepareCompleted?: boolean; preparePending?: boolean } = {},
+  providers: ProviderBundle
+): Promise<{
+  results: TrackingResult[];
+  preparations: PrepareResult[];
+  preparedTransactions: PreparedTransaction[];
+}> {
   const results = await tracker.trackByTxHash(txHash);
   const preparations: PrepareResult[] = [];
+  const preparedTransactions: PreparedTransaction[] = [];
 
   for (const result of results) {
-    const prepResult = await prepareStagesForResult(tracker, result.stages, options);
+    const prepResult = await prepareStagesForResult(tracker, result.stages, options, providers);
     preparations.push(...prepResult.preparations);
+    preparedTransactions.push(...prepResult.preparedTransactions);
   }
 
-  return { results, preparations };
+  return { results, preparations, preparedTransactions };
 }

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -38,7 +38,7 @@ import {
   createSigner,
   requirePrivateKeyForWrite,
   executeTransaction,
-  formatDryRun,
+  formatMultiplePreparedTransactions,
   formatTrackingResult,
   formatCacheStatus,
   runWithLoop,
@@ -138,7 +138,7 @@ runCmd
   .option("--prepare", "Prepare transactions for ready stages (dry-run)")
   .option("--write", "Execute prepared transactions (requires --private-key)")
   .addOption(new Option("--private-key <key>", "Private key for execution").env("PRIVATE_KEY"))
-  .option("--force", "Force prepare even for completed stages (historical validation)")
+  .option("--prepare-completed", "Prepare completed stages (for historical validation)")
   .option("--prepare-pending", "Prepare pending stages (waiting for delays)")
   .option("--loop", "Run in continuous loop")
   .option("--interval <seconds>", "Loop interval in seconds", "60")
@@ -206,49 +206,53 @@ runCmd
       const cycleStartBlock = isFirstCycle ? startBlock : undefined;
       isFirstCycle = false;
 
-      const { result, proposals, timelockOps } = await runMonitorCycle(
-        tracker,
-        providers.l2Provider,
-        {
-          prepare: opts.prepare || opts.write || opts.force || opts.preparePending,
-          force: opts.force,
-          preparePending: opts.preparePending,
-          startBlock: cycleStartBlock,
-          blockLag,
-          maxAgeDays,
-          concurrency,
-          onTrack: async (r): Promise<TrackCallbackReturn> => {
-            // Skip showing complete elections
-            if (r.result?.isElection && r.result?.isComplete) {
-              electionsSkipped++;
-              return {};
-            }
+      const { result, proposals, timelockOps } = await runMonitorCycle(tracker, providers, {
+        prepare: opts.prepare || opts.write || opts.prepareCompleted || opts.preparePending,
+        prepareCompleted: opts.prepareCompleted,
+        preparePending: opts.preparePending,
+        startBlock: cycleStartBlock,
+        blockLag,
+        maxAgeDays,
+        concurrency,
+        onTrack: async (r): Promise<TrackCallbackReturn> => {
+          // Skip showing complete elections
+          if (r.result?.isElection && r.result?.isComplete) {
+            electionsSkipped++;
+            return {};
+          }
 
-            if (r.result) {
-              console.log(`\n[${r.key}]`);
-              console.log(formatTrackingResult(r.result));
-            } else if (r.error) {
-              console.log(`\n[${r.key}] ERROR: ${r.error}`);
-            }
+          if (r.result) {
+            console.log(`\n[${r.key}]`);
+            console.log(formatTrackingResult(r.result));
+          } else if (r.error) {
+            console.log(`\n[${r.key}] ERROR: ${r.error}`);
+          }
 
-            if (r.prepared) {
-              console.log(`\n[PREPARED] ${r.key}`);
-              console.log(formatDryRun(r.prepared));
+          // Use preparedTransactions if available, otherwise fall back to prepared (legacy)
+          const txsToDisplay = r.preparedTransactions ?? (r.prepared ? [r.prepared] : []);
+          if (txsToDisplay.length > 0) {
+            console.log(`\n[PREPARED] ${r.key}`);
+            console.log(formatMultiplePreparedTransactions(txsToDisplay));
 
-              if (signer) {
-                const execResult = await executeTransaction(r.prepared, signer, providers);
+            if (signer) {
+              let executedAny = false;
+              for (const prepared of txsToDisplay) {
+                const execResult = await executeTransaction(prepared, signer, providers);
                 if (!execResult.success) {
                   console.error(`  Execution failed: ${execResult.error}`);
-                  return {};
+                } else {
+                  executedAny = true;
                 }
+              }
+              if (executedAny) {
                 console.log(`  Executed! Re-tracking to find next stages...`);
                 return { shouldRetrack: true };
               }
             }
-            return {};
-          },
-        }
-      );
+          }
+          return {};
+        },
+      });
 
       const stats = await tracker.getStats();
       console.log(
@@ -304,7 +308,7 @@ trackCmd
   .option("--prepare", "Prepare transactions for ready stages (dry-run)")
   .option("--write", "Execute prepared transactions (requires --private-key)")
   .addOption(new Option("--private-key <key>", "Private key for execution").env("PRIVATE_KEY"))
-  .option("--force", "Force prepare even for completed stages (historical validation)")
+  .option("--prepare-completed", "Prepare completed stages (for historical validation)")
   .option("--prepare-pending", "Prepare pending stages (waiting for delays)")
   .option(
     "--l1-chunk-size <size>",
@@ -343,55 +347,63 @@ trackCmd
         chunkingConfig,
         onProgress: opts.concurrency === "1" || opts.verbose ? createProgressCallback() : undefined,
       });
-      const shouldPrepare = opts.prepare || opts.write || opts.force || opts.preparePending;
+      const shouldPrepare =
+        opts.prepare || opts.write || opts.prepareCompleted || opts.preparePending;
 
-      const { results, preparations } = await trackAndPrepare(tracker, opts.tx, {
-        prepare: shouldPrepare,
-        force: opts.force,
-        preparePending: opts.preparePending,
-      });
+      const { results, preparations, preparedTransactions } = await trackAndPrepare(
+        tracker,
+        opts.tx,
+        {
+          prepare: shouldPrepare,
+          prepareCompleted: opts.prepareCompleted,
+          preparePending: opts.preparePending,
+        },
+        providers
+      );
 
       // Format output
       results.forEach((r, i) => {
         const label = results.length > 1 ? `Operation ${i + 1}/${results.length}` : undefined;
         console.log(formatTrackingResult(r, label));
       });
-      preparations.forEach((prep) => {
-        if (prep.success && prep.prepared) {
-          console.log(`\n${formatDryRun(prep.prepared)}`);
-        } else if (!prep.success) {
-          console.log(`\n[PREPARE ERROR] ${prep.error}`);
-        }
+
+      // Show all prepared transactions
+      if (preparedTransactions.length > 0) {
+        console.log(`\n${formatMultiplePreparedTransactions(preparedTransactions)}`);
+      }
+
+      // Show preparation errors
+      const failedPreparations = preparations.filter((p) => !p.success);
+      failedPreparations.forEach((prep) => {
+        console.log(`\n[PREPARE ERROR] ${prep.error}`);
       });
 
       // Execute if --write
-      if (opts.write && preparations.length > 0) {
+      if (opts.write && preparedTransactions.length > 0) {
         const signer = createSigner(opts.privateKey);
         console.log(`\n=== Executing with ${signer.address} ===`);
 
-        let currentPreparations = preparations;
+        let currentPreparedTxs = preparedTransactions;
         let chainDepth = 0;
         const maxChainDepth = 10;
 
-        while (currentPreparations.length > 0 && chainDepth < maxChainDepth) {
+        while (currentPreparedTxs.length > 0 && chainDepth < maxChainDepth) {
           chainDepth++;
           let executedAny = false;
 
-          for (const prep of currentPreparations) {
-            if (prep.success && prep.prepared) {
-              const result = await executeTransaction(prep.prepared, signer, providers);
-              if (!result.success) {
-                console.error(`Execution failed: ${result.error}`);
-              } else {
-                executedAny = true;
-              }
+          for (const prepared of currentPreparedTxs) {
+            const result = await executeTransaction(prepared, signer, providers);
+            if (!result.success) {
+              console.error(`Execution failed: ${result.error}`);
+            } else {
+              executedAny = true;
             }
           }
 
           if (!executedAny) break;
 
           console.log(`\nRe-tracking to find next stages...`);
-          const retracked = await trackAndPrepare(tracker, opts.tx, { prepare: true });
+          const retracked = await trackAndPrepare(tracker, opts.tx, { prepare: true }, providers);
 
           retracked.results.forEach((r, i) => {
             const label =
@@ -400,12 +412,17 @@ trackCmd
                 : undefined;
             console.log(formatTrackingResult(r, label));
           });
-          retracked.preparations.forEach((prep) => {
-            if (prep.success && prep.prepared) console.log(`\n${formatDryRun(prep.prepared)}`);
-            else if (!prep.success) console.log(`\n[PREPARE ERROR] ${prep.error}`);
+
+          if (retracked.preparedTransactions.length > 0) {
+            console.log(`\n${formatMultiplePreparedTransactions(retracked.preparedTransactions)}`);
+          }
+
+          const retrackedFailed = retracked.preparations.filter((p) => !p.success);
+          retrackedFailed.forEach((prep) => {
+            console.log(`\n[PREPARE ERROR] ${prep.error}`);
           });
 
-          currentPreparations = retracked.preparations;
+          currentPreparedTxs = retracked.preparedTransactions;
         }
       }
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,9 @@ export type { StageMetadata } from "./utils/stage-metadata";
 // Address utilities
 export { addressEquals, isAddressIn, getChainType } from "./utils/chain";
 
+// Error classification
+export { isGasEstimationError } from "./utils/error-classification";
+
 // ============================================================================
 // TIER 5: Election Tracking
 // ============================================================================

--- a/src/stages/l2-to-l1-message.ts
+++ b/src/stages/l2-to-l1-message.ts
@@ -441,8 +441,8 @@ export async function trackL2ToL1Message(
  * Options for preparing L2→L1 messages
  */
 export interface OutboxPrepareOptions {
-  /** Force preparation even if stage is completed (for historical validation) */
-  force?: boolean;
+  /** Prepare completed stages (for historical validation) */
+  prepareCompleted?: boolean;
   /** Outbox contract address (resolved automatically if not provided) */
   outboxAddress?: string;
 }
@@ -463,8 +463,8 @@ export async function prepareL2ToL1Message(
   const status = await queryWithRetry(() => reader.status(l2Provider));
   logExecution("Message status: %s", ChildToParentMessageStatus[status]);
 
-  // Skip state check if force=true for historical validation
-  if (!options.force) {
+  // Skip state check if prepareCompleted=true for historical validation
+  if (!options.prepareCompleted) {
     if (status === ChildToParentMessageStatus.EXECUTED) {
       return failPrepare("Message already executed");
     }
@@ -543,7 +543,9 @@ export async function prepareL2ToL1MessageStage(
   l1Provider: ethers.providers.Provider,
   options: OutboxPrepareOptions = {}
 ): Promise<SimpleBulkResult> {
-  const validationError = validateStageForSimpleBulk(stage, { force: options.force });
+  const validationError = validateStageForSimpleBulk(stage, {
+    prepareCompleted: options.prepareCompleted,
+  });
   if (validationError) return validationError;
 
   const stageData = getStageData(stage, "L2_TO_L1_MESSAGE");

--- a/src/stages/retryables.ts
+++ b/src/stages/retryables.ts
@@ -342,8 +342,8 @@ export async function trackRetryables(
  * Options for preparing retryable tickets
  */
 export interface RetryablePrepareOptions {
-  /** Force preparation even if stage is completed (for historical validation) */
-  force?: boolean;
+  /** Prepare completed stages (for historical validation) */
+  prepareCompleted?: boolean;
 }
 
 /**
@@ -360,8 +360,8 @@ export async function prepareRetryableRedemption(
   const status = await queryWithRetry(() => message.status());
   log("Retryable status: %s", ParentToChildMessageStatus[status]);
 
-  // Skip status check if force=true for historical validation
-  if (!options.force) {
+  // Skip status check if prepareCompleted=true for historical validation
+  if (!options.prepareCompleted) {
     if (status === ParentToChildMessageStatus.REDEEMED) {
       return failPrepare("Retryable already redeemed");
     }
@@ -424,7 +424,9 @@ export async function prepareRetryableStage(
   l2Provider: ethers.providers.Provider,
   options: RetryablePrepareOptions = {}
 ): Promise<BulkPrepareResult> {
-  const validationError = validateStageForBulkPrepare(stage, "L2", { force: options.force });
+  const validationError = validateStageForBulkPrepare(stage, "L2", {
+    prepareCompleted: options.prepareCompleted,
+  });
   if (validationError) return validationError;
 
   const l1TxHash = stage.transactions[0]?.hash;

--- a/src/stages/timelock.ts
+++ b/src/stages/timelock.ts
@@ -638,7 +638,7 @@ export async function prepareTimelockOperation(
   const salt = getSalt(stageData, options);
   const predecessor = getPredecessor(stageData, options);
 
-  if (!options.force) {
+  if (!options.prepareCompleted) {
     const stateError = await checkOperationReady(timelockAddress, operationId, provider);
     if (stateError) return stateError;
   }
@@ -715,7 +715,7 @@ export async function prepareTimelockBatch(
   const salt = getSalt(stageData, options);
   const predecessor = getPredecessor(stageData, options);
 
-  if (!options.force) {
+  if (!options.prepareCompleted) {
     const stateError = await checkOperationReady(timelockAddress, operationId, provider);
     if (stateError) return stateError;
   }
@@ -791,7 +791,9 @@ export async function prepareTimelockStage(
   provider: ethers.providers.Provider,
   options: PrepareOptions = {}
 ): Promise<PrepareResult> {
-  const validationError = validateStageForPrepare(stage, { force: options.force });
+  const validationError = validateStageForPrepare(stage, {
+    prepareCompleted: options.prepareCompleted,
+  });
   if (validationError) return validationError;
 
   const stageData = createTimelockStageData(stage);

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -14,6 +14,7 @@
 
 import { ethers } from "ethers";
 import { loggers } from "./utils/logger";
+import { isGasEstimationError } from "./utils/error-classification";
 import {
   TrackerOptions,
   TrackingResult,
@@ -361,6 +362,7 @@ export class ProposalStageTracker {
       return await this.trackByTxHashInternal(txHash, cacheKey, checkpoint);
     } catch (error) {
       // Save checkpoint on error with incremented error count
+      // Gas estimation errors don't count against consecutive errors
       if (this.cache) {
         const input: GovernorTrackingInput = {
           type: "governor",
@@ -369,6 +371,9 @@ export class ProposalStageTracker {
           creationTxHash: txHash,
         };
         const prevErrorCount = checkpoint?.metadata?.errorCount ?? 0;
+        const isGasError = isGasEstimationError(error);
+        const newErrorCount = isGasError ? prevErrorCount : prevErrorCount + 1;
+
         const errorCheckpoint: TrackingCheckpoint = checkpoint ?? {
           version: 1,
           createdAt: Date.now(),
@@ -377,9 +382,14 @@ export class ProposalStageTracker {
           lastProcessedBlock: { l1: 0, l2: 0 },
           cachedData: {},
         };
-        errorCheckpoint.metadata = { errorCount: prevErrorCount + 1, lastTrackedAt: Date.now() };
+        errorCheckpoint.metadata = { errorCount: newErrorCount, lastTrackedAt: Date.now() };
         await this.cache.set(cacheKey, errorCheckpoint);
-        logTracker("saved checkpoint on error: %s (errorCount=%d)", cacheKey, prevErrorCount + 1);
+        logTracker(
+          "saved checkpoint on error: %s (errorCount=%d%s)",
+          cacheKey,
+          newErrorCount,
+          isGasError ? " - gas error, not incrementing" : ""
+        );
       }
       throw error;
     }

--- a/src/tracker/execute.ts
+++ b/src/tracker/execute.ts
@@ -96,23 +96,29 @@ export async function prepareTransaction(
 
     case "L2_TO_L1_MESSAGE": {
       const { total, results } = await prepareL2ToL1MessageStage(stage, l2Provider, l1Provider, {
-        force: options.force,
+        prepareCompleted: options.prepareCompleted,
       });
       if (results.length === 0) {
         return failPrepare("No messages to prepare");
       }
-      // If there are multiple messages, return success but include warning about additional messages
-      if (total > 1 && results[0].success) {
-        return {
-          ...results[0],
-          prepared: {
-            ...results[0].prepared,
-            description:
-              results[0].prepared.description +
-              ` [1/${total} messages - use prepareL2ToL1MessageStage() for all]`,
-          },
-        };
+      // Find first successful result
+      const successResult = results.find((r) => r.success);
+      if (successResult) {
+        // If there are multiple messages, include warning about additional messages
+        if (total > 1) {
+          return {
+            ...successResult,
+            prepared: {
+              ...successResult.prepared,
+              description:
+                successResult.prepared.description +
+                ` [1/${total} messages - use prepareL2ToL1MessageStage() for all]`,
+            },
+          };
+        }
+        return successResult;
       }
+      // All failed, return first result
       return results[0];
     }
 
@@ -128,23 +134,29 @@ export async function prepareTransaction(
         return failPrepare("Target chain provider not available");
       }
       const { total, results } = await prepareRetryableStage(stage, l1Provider, targetProvider, {
-        force: options.force,
+        prepareCompleted: options.prepareCompleted,
       });
       if (results.length === 0) {
         return failPrepare("No tickets to prepare");
       }
-      // If there are multiple tickets, return success but include warning
-      if (total > 1 && results[0].success) {
-        return {
-          ...results[0],
-          prepared: {
-            ...results[0].prepared,
-            description:
-              results[0].prepared.description +
-              ` [1/${total} tickets - use prepareRetryableStage() for all]`,
-          },
-        };
+      // Find first successful result
+      const successResult = results.find((r) => r.success);
+      if (successResult) {
+        // If there are multiple tickets, include warning
+        if (total > 1) {
+          return {
+            ...successResult,
+            prepared: {
+              ...successResult.prepared,
+              description:
+                successResult.prepared.description +
+                ` [1/${total} tickets - use prepareRetryableStage() for all]`,
+            },
+          };
+        }
+        return successResult;
       }
+      // All failed, return first result
       return results[0];
     }
 

--- a/src/types/tracking.ts
+++ b/src/types/tracking.ts
@@ -16,7 +16,8 @@ export interface PrepareOptions {
   predecessor?: string;
   skipSaltValidation?: boolean;
   skipRetryableValueCalculation?: boolean;
-  force?: boolean;
+  /** Prepare completed stages (for historical validation) */
+  prepareCompleted?: boolean;
   /** Proposal description (needed for salt derivation if not in stage data) */
   description?: string;
 }

--- a/src/utils/error-classification.ts
+++ b/src/utils/error-classification.ts
@@ -1,0 +1,28 @@
+/**
+ * Error Classification Utilities
+ *
+ * Classifies errors for better error handling and tracking.
+ */
+
+/**
+ * Check if an error is a gas estimation error.
+ * Gas estimation errors should not count against consecutive error tracking
+ * because they are often temporary (insufficient funds, contract state changes, etc.)
+ * and should be retried in the next run.
+ */
+export function isGasEstimationError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    message.includes("gas required exceeds") ||
+    message.includes("execution reverted") ||
+    message.includes("out of gas") ||
+    message.includes("intrinsic gas too low") ||
+    message.includes("insufficient funds for gas") ||
+    message.includes("cannot estimate gas") ||
+    message.includes("gas estimation") ||
+    message.includes("transaction may fail") ||
+    message.includes("gas limit") ||
+    message.includes("revert")
+  );
+}

--- a/src/utils/stage-helpers.ts
+++ b/src/utils/stage-helpers.ts
@@ -130,7 +130,7 @@ export function buildExecutionPayloadData(
 // ============================================================================
 
 export interface PrepareValidationOptions {
-  force?: boolean;
+  prepareCompleted?: boolean;
   expectedTypes?: StageType[];
 }
 
@@ -139,7 +139,7 @@ export function validateStageForPrepare(
   stage: TrackedStage,
   options: PrepareValidationOptions = {}
 ): PrepareResult | null {
-  if (!options.force && stage.status !== "READY") {
+  if (!options.prepareCompleted && stage.status !== "READY") {
     return failPrepare(`Stage is not ready. Current status: ${stage.status}`);
   }
   if (options.expectedTypes?.length && !options.expectedTypes.includes(stage.type)) {

--- a/test/stage-helpers.test.ts
+++ b/test/stage-helpers.test.ts
@@ -487,10 +487,10 @@ describe("validateStageForPrepare", () => {
     expect(result?.error).toContain("not ready");
   });
 
-  it("should allow non-READY with force=true", () => {
+  it("should allow non-READY with prepareCompleted=true", () => {
     const stage = new StageBuilder("L2_TIMELOCK", "L2").status("PENDING").build();
 
-    const result = validateStageForPrepare(stage, { force: true });
+    const result = validateStageForPrepare(stage, { prepareCompleted: true });
 
     expect(result).toBeNull();
   });


### PR DESCRIPTION
- Fix: show all prepared transactions for retryables and L2→L1 messages
- Show multiple prepared txs with [DRY RUN 1/N] format
- Execute all prepared transactions when using --write
- Handle multiple target chains (Arb1 and Nova) for retryables
- Add gas estimation error classification
- Gas errors don't increment consecutive error count
- Remove retryable retry loop (now retries only across runs)
- Rename --force flag to --prepare-completed for clarity