### PR TITLE
fix: increase test timeout from 2 to 30 minutes

### DIFF
--- a/vitest.config.fork.mts
+++ b/vitest.config.fork.mts
@@ -11,6 +11,6 @@ export default defineConfig({
     // Disable file parallelism
     fileParallelism: false,
     // Increase global timeout
-    testTimeout: 300000,
+    testTimeout: 1800000,
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,6 +9,6 @@ export default defineConfig({
     coverage: {
       reporter: ["text", "json", "html"],
     },
-    testTimeout: 300000
+    testTimeout: 1800000
   },
 });


### PR DESCRIPTION
Increase testTimeout in both vitest.config.mts and vitest.config.fork.mts from 120000ms (2 minutes) to 1800000ms (30 minutes) to prevent CI timeouts.

Closes #4

Generated with [Claude Code](https://claude.ai/code)