### PR TITLE
release: v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,12 +27,13 @@ npm-debug.log*
 # Test coverage
 coverage/
 coverage-merged/
+coverage-fork/
+junit.xml
 
 # Environment
 .env
 .env.local
 .env.*.local
-coverage-fork/
 
 # opensrc - source code for packages
 opensrc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-13
+
 ### Added
 
+- **Delegate Indexing & Query module** (`src/delegates/`) - Cache, query, and live lookups for ARB delegates. Upstreams ~900 LOC from `tally-zero` into the SDK.
+  - Cache access (sync, no RPC): `loadBundledDelegateCache()`, `extractDelegates()`, `getDelegateCacheStats()`, `validateDelegateCache()` type guard, `serializeDelegateCache()`, `getBundledDelegateCachePath()`, `DELEGATE_CACHE_VERSION`
+  - Query helpers (sync): `getTopDelegates(cache, limit?)`, `getDelegateRankInfo(cache, address)` (O(1) rank + voting power via WeakMap), `filterDelegatesByMinPower()`, `filterDelegatesByAddress()`
+  - Live queries (async): `queryDelegatesNotVoted(provider, proposalId, governor, options?)` — multicall-batched `hasVoted` checks for top delegates. `queryDelegateVotingPowers(provider, addresses, tokenAddress?)` — multicall-batched `getVotes()`
+  - Indexer: `buildDelegateCache(provider, options?)` — adaptive-chunked scan of `DelegateVotesChanged`, halving on RPC log-limit errors and recovering after consecutive successes. Streams events per-chunk to avoid OOM on full genesis builds. Options: `existingCache`, `force`, `startBlock`, `minVotingPower` (default 10 ARB), `tokenAddress`, `onProgress`
+  - Types: `DelegateInfo`, `DelegateCache`, `DelegateCacheStats`, `DelegateNotVoted`, `BuildDelegateCacheOptions`, `QueryDelegatesNotVotedOptions`
+  - Constants: `DELEGATE_START_BLOCK`, `EXCLUDED_DELEGATE_ADDRESSES`, `DEFAULT_MIN_VOTING_POWER`
+  - ERC20Votes ABI additions: `totalSupply()` and `DelegateVotesChanged` event. New `DELEGATE_VOTES_CHANGED` topic in `EVENT_TOPICS`
+  - Bundled cache: `data/delegate-cache.json` exported at `@gzeoneth/gov-tracker/delegate-cache.json`
+- **CLI: `delegates` subcommand** - `gov-tracker delegates [--force] [--start-block N] [--output path] [--min-power wei] [--token-address 0x...]` builds/updates delegate cache from live RPC. Scripts: `cache:delegates`, `cache:delegates:force`
 - **Governance vote preparation** - Prepare-only functions for voting on Core/Treasury Governor proposals:
   - `prepareCastVote(proposalId, support)` - Simple vote (For/Against/Abstain)
   - `prepareCastVoteWithReason(proposalId, support, reason)` - Vote with on-chain reason
@@ -17,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Governor shorthand: pass `"constitutional"` or `"non-constitutional"` instead of addresses
 - **Operation ID hashing (public)** - `hashOperation()` and `hashOperationBatch()` now exported from public API (previously internal-only)
 - **Governor ABI additions** - Added `castVote`, `castVoteWithReason`, `castVoteWithReasonAndParams`, `castVoteBySig`, `getVotes`, `hasVoted`, `ProposalCreated` event to `GOVERNOR_ABI`
-- **ERC20Votes ABI additions** - Added `getVotes(address)` (current voting power without block number) and `delegates(address)` to `ERC20_VOTES_ABI`
+- **ERC20Votes ABI read helpers** - Added `getVotes(address)` (current voting power without block number) and `delegates(address)` to `ERC20_VOTES_ABI`
 - **Election write actions** - Prepare-only functions for election participation (contender registration, vote casting):
   - `encodeElectionVoteParams()` / `decodeElectionVoteParams()` - ABI encode/decode `(address, uint256)` vote params
   - `getAddContenderTypedData()` - Build EIP-712 typed data for contender registration signing
@@ -60,12 +72,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getWatermarksFromCache()` - Get discovery watermarks from cache
   - `getVotingDataFromStages()` - Extract typed vote data from stages
   - `extractTimelockLinkFromStages()` - Extract TimelockLink from completed stages
-- `getAllStageMetadata()` - Memoized function returning `Record<StageType, StageMetadata>` for all stage types
-- `ALL_STAGE_TYPES` - Constant array of all stage types in pipeline order
-- `trimFromStage(checkpoint, stageIndex)` - Trim checkpoint stages for re-tracking scenarios
-- `getLifecyclePhase(stages)` - Returns human-readable `LifecyclePhase`: `voting`, `queued`, `l2_delay`, `bridging`, `l1_delay`, `finalizing`, `executed`, `failed`, `unknown`
-- `loadWatermarks()` / `LoadedWatermarks` - Access discovery watermarks from cache
-- `getErrorMessage()` - Shared error message extraction utility
+- **Stage metadata helpers** - `getAllStageMetadata()` returns a memoized `Record<StageType, StageMetadata>`; `ALL_STAGE_TYPES` constant exposes stage types in pipeline order
+- **Checkpoint re-tracking** - `trimFromStage(checkpoint, stageIndex)` trims stages for re-tracking scenarios
+- **Lifecycle phase helper** - `getLifecyclePhase(stages)` returns a human-readable `LifecyclePhase`: `voting`, `queued`, `l2_delay`, `bridging`, `l1_delay`, `finalizing`, `executed`, `failed`, `unknown`
+- **Watermark access** - `loadWatermarks()` / `LoadedWatermarks` type expose discovery watermarks from cache
+- **Error utility** - `getErrorMessage()` shared error-message extraction utility now exported
 
 ### Fixed
 
@@ -90,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Robustness** - `Promise.allSettled` for watermark verification; graceful fallback for Arbitrum network detection
 - **Type safety** - `RetryableSimulationData.l2Chain` changed to `L2Chain | "unknown"`
 - **Code consolidation** - Time constants centralized in `TIMING` object; address comparison uses shared utilities
+- **Scripts** - `cache:generate` is now incremental by default; `cache:generate:force` rebuilds from scratch (was a single `--force` script before). Refreshed bundled proposal cache
 
 ### Refactored
 
@@ -298,7 +310,8 @@ Initial release with 7-stage governance tracking across Ethereum L1, Arbitrum On
 
 ---
 
-[Unreleased]: https://github.com/gzeoneth/gov-tracker/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/gzeoneth/gov-tracker/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/gzeoneth/gov-tracker/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gzeoneth/gov-tracker/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gzeoneth/gov-tracker/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/gzeoneth/gov-tracker/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/gzeoneth/gov-tracker/graph/badge.svg?token=2WVH8Z82TE)](https://codecov.io/gh/gzeoneth/gov-tracker)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Track and execute Arbitrum DAO governance proposal lifecycle stages and Security Council elections.
+Track and execute Arbitrum DAO governance proposal lifecycle stages, Security Council elections, and delegate participation.
 
 ## Installation
 
@@ -55,6 +55,76 @@ if (readyStage) {
 
 Statuses: `NOT_STARTED`, `PENDING`, `READY`, `COMPLETED`, `FAILED`, `SKIPPED`
 
+## Voting & Write Actions
+
+Prepare-only functions return `PreparedTransaction` objects — `{ to, data, value, chain, chainId, description }` plus optional `operationId` / `hashValidation` — and you always sign and send yourself.
+
+```typescript
+import { ethers } from "ethers";
+import {
+  prepareCastVote,
+  prepareCastVoteWithReason,
+  VOTE_SUPPORT,
+  prepareNomineeElectionVote,
+  prepareContenderRegistration,
+  NOMINEE_ELECTION_GOVERNOR_ABI,
+  ADDRESSES,
+} from "@gzeoneth/gov-tracker";
+
+// Governor proposal vote
+const tx = prepareCastVote(proposalId, VOTE_SUPPORT.FOR, "constitutional");
+await signer.sendTransaction(tx);
+
+// Vote with on-chain reason
+const tx2 = prepareCastVoteWithReason(proposalId, VOTE_SUPPORT.AGAINST, "Insufficient detail");
+
+// Security Council nominee vote (castVoteWithReasonAndParams)
+const tx3 = prepareNomineeElectionVote(proposalId, nomineeAddress, votes);
+
+// Contender registration (two-phase: sign EIP-712 typed data, then submit)
+// governorName MUST match the governor's on-chain name() value (EIP-712 domain)
+const governor = new ethers.Contract(
+  ADDRESSES.ELECTION_NOMINEE_GOVERNOR,
+  NOMINEE_ELECTION_GOVERNOR_ABI,
+  l2Provider
+);
+const governorName: string = await governor.name();
+const { typedData, buildTransaction } = prepareContenderRegistration(governorName, proposalId);
+const signature = await signer._signTypedData(typedData.domain, typedData.types, typedData.message);
+await signer.sendTransaction(buildTransaction(signature));
+```
+
+See [API Reference](./docs/API.md#governance-vote-preparation) and [Examples](./docs/EXAMPLES.md#voting) for details.
+
+## Delegates
+
+Indexed ARB delegate registry with cached voting power and live queries:
+
+```typescript
+import {
+  loadBundledDelegateCache,
+  getTopDelegates,
+  getDelegateRankInfo,
+  queryDelegatesNotVoted,
+} from "@gzeoneth/gov-tracker";
+
+// Load bundled cache (sync, no RPC)
+const cache = loadBundledDelegateCache();
+const top10 = getTopDelegates(cache, 10);
+
+// O(1) rank lookup
+const info = getDelegateRankInfo(cache, "0x1234...");
+console.log(`Rank ${info?.rank}, voting power ${info?.votingPower}`);
+
+// Live: find top delegates who haven't voted yet on an active proposal
+const notVoted = await queryDelegatesNotVoted(l2Provider, proposalId, "constitutional", {
+  limit: 10,
+  maxDelegatesToCheck: 100,
+});
+```
+
+Build or refresh the cache via CLI: `npx @gzeoneth/gov-tracker delegates`.
+
 ## CLI
 
 ```bash
@@ -93,6 +163,12 @@ npx @gzeoneth/gov-tracker ui
 
 # Track election creation tx (auto-switches to election view)
 npx @gzeoneth/gov-tracker track 0x82a0baf3...
+
+# Build or refresh delegate cache from live RPC
+npx @gzeoneth/gov-tracker delegates                          # Incremental update
+npx @gzeoneth/gov-tracker delegates --force                  # Rebuild from genesis
+npx @gzeoneth/gov-tracker delegates --min-power 1000 \
+  --output ./my-delegates.json                               # Custom filters/output
 ```
 
 **Shorthands:** `-v` (verbose), `-p` (prepare), `-w` (write), `-i` (inspect)

--- a/docs/API.md
+++ b/docs/API.md
@@ -622,6 +622,117 @@ for (const p of proposals) {
 
 ---
 
+### Delegate Indexing & Query
+
+Indexed ARB delegate registry for governance tooling — ranked list of delegates by voting power, with helpers for cache access, filtering, and live on-chain queries.
+
+#### Cache Access (sync, no RPC)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `loadBundledDelegateCache()` | `DelegateCache` | Load & validate bundled cache; throws if missing/invalid |
+| `getBundledDelegateCachePath()` | `string \| undefined` | Path to `delegate-cache.json` on disk (checks dist/src layouts) |
+| `extractDelegates(cache)` | `DelegateInfo[]` | Extract sorted delegate list |
+| `getDelegateCacheStats(cache)` | `DelegateCacheStats` | Summary stats for display |
+| `validateDelegateCache(data)` | `data is DelegateCache` | Type guard (also deserializes compact on-disk format) |
+| `serializeDelegateCache(cache)` | `Record<string, unknown>` | Convert to disk format (compact keys) |
+
+```typescript
+import { loadBundledDelegateCache, getDelegateCacheStats } from "@gzeoneth/gov-tracker";
+
+const cache = loadBundledDelegateCache();
+const stats = getDelegateCacheStats(cache);
+console.log(`${stats.totalDelegates} delegates, snapshot @ block ${stats.snapshotBlock}`);
+```
+
+#### Query Helpers (sync)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `getTopDelegates(cache, limit?)` | `DelegateInfo[]` | Top N delegates (list is already sorted desc by power) |
+| `getDelegateRankInfo(cache, address)` | `{ rank, votingPower } \| undefined` | O(1) rank + power lookup via WeakMap-cached index |
+| `filterDelegatesByMinPower(delegates, minWei)` | `DelegateInfo[]` | Filter by voting power threshold (wei string) |
+| `filterDelegatesByAddress(delegates, substring)` | `DelegateInfo[]` | Case-insensitive address substring filter |
+
+#### Live Queries (async, requires provider)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `queryDelegatesNotVoted(provider, proposalId, governor, options?)` | `Promise<DelegateNotVoted[]>` | Multicall-batched `hasVoted()` checks for top delegates on an active proposal |
+| `queryDelegateVotingPowers(provider, addresses, tokenAddress?)` | `Promise<Map<string, string>>` | Multicall-batched `getVotes()` — returns `lowercaseAddress → weiString` |
+
+`QueryDelegatesNotVotedOptions`:
+
+```typescript
+{
+  cache?: DelegateCache;       // Default: loads bundled cache
+  limit?: number;              // Max results (default: 5)
+  maxDelegatesToCheck?: number; // Top N to inspect (default: 100)
+  batchSize?: number;          // Calls per multicall batch (default: 20)
+}
+```
+
+```typescript
+import { queryDelegatesNotVoted } from "@gzeoneth/gov-tracker";
+
+const notVoted = await queryDelegatesNotVoted(l2Provider, proposalId, "constitutional", {
+  limit: 10,
+  maxDelegatesToCheck: 100,
+});
+for (const d of notVoted) {
+  console.log(`#${d.rank} ${d.address} — ${d.votingPower} wei`);
+}
+```
+
+#### Indexer (async)
+
+Build or refresh the cache by scanning `DelegateVotesChanged` events with adaptive chunking that halves on RPC log-limit errors and recovers after consecutive successes. Events are streamed per-chunk to avoid OOM on genesis-wide scans.
+
+```typescript
+import { buildDelegateCache } from "@gzeoneth/gov-tracker";
+
+const cache = await buildDelegateCache(l2Provider, {
+  existingCache,              // Seed from prior cache (incremental)
+  force: false,               // Rescan from genesis
+  startBlock: 70_000_000,     // Override start (default: DELEGATE_START_BLOCK)
+  minVotingPower: "10...",    // Wei threshold (default: 10 ARB)
+  tokenAddress: ADDRESSES.ARB_TOKEN,
+  onProgress: (pct, block) => console.log(`${pct.toFixed(1)}% — block ${block}`),
+});
+```
+
+**Types:**
+
+```typescript
+interface DelegateInfo {
+  address: `0x${string}`;
+  votingPower: string;        // wei as decimal string
+  lastChangeBlock: number;
+}
+
+interface DelegateCache {
+  version: number;
+  generatedAt: string;        // ISO timestamp
+  snapshotBlock: number;      // latest indexed block
+  startBlock: number;
+  chainId: number;
+  totalVotingPower: string;   // wei
+  totalSupply: string;        // ARB token total supply (wei)
+  delegates: DelegateInfo[];  // sorted desc by votingPower
+  stats: { totalDelegates: number };
+}
+
+interface DelegateNotVoted {
+  address: `0x${string}`;
+  votingPower: string;
+  rank: number;               // 1-indexed
+}
+```
+
+**Constants:** `DELEGATE_START_BLOCK`, `EXCLUDED_DELEGATE_ADDRESSES`, `DEFAULT_MIN_VOTING_POWER`, `DELEGATE_CACHE_VERSION`.
+
+---
+
 ### Checkpoint Deduplication
 
 Both governance proposals and elections can create "child" timelock operations that may be discovered and tracked separately. The deduplication helpers identify and manage these relationships.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,7 @@ src/
 ├── stages/              # Individual stage implementations
 ├── election/            # Security Council election tracking (8 files)
 ├── governance/          # Governance vote preparation + wagmi read helpers
+├── delegates/           # Delegate indexing (cache/indexer/queries) + bundled cache
 ├── calldata/            # Calldata decoding and signature lookup
 ├── simulation/          # Simulation data preparation (Tenderly, etc.)
 ├── discovery/           # Governor & timelock introspection
@@ -177,6 +178,26 @@ All write-action modules follow the same pattern: encode transaction calldata an
 ### Chain derivation
 
 Write-action functions that accept a `chainId` parameter derive the `chain` field via `chainIdToChain(chainId)` rather than hardcoding it. Functions without a `chainId` parameter (e.g., `prepareElectionCreation`, `prepareGovernorQueue`) use `chain: "arb1"` and `chainId: 42161` inline since they are Arbitrum One-specific.
+
+---
+
+## Delegate Module
+
+The `src/delegates/` module provides three layers for ARB delegate tooling:
+
+| Layer | File | Responsibilities |
+|-------|------|------------------|
+| Cache access (sync) | `cache.ts` | Load/validate bundled cache, serialize for disk, filter/rank helpers, O(1) rank lookup via WeakMap |
+| Indexer (async) | `indexer.ts` | Scan `DelegateVotesChanged` with adaptive chunking, stream events per-chunk to avoid OOM |
+| Live queries (async) | `queries.ts` | Multicall-batched `hasVoted()` / `getVotes()` against the ARB token + governor contracts |
+
+### Adaptive Chunking
+
+The indexer's `fetchLogsWithAdaptiveChunking` helper halves the chunk size on RPC log-limit errors and grows it back after N consecutive successes. This lets the same code work against both high-capacity providers (Alchemy, Infura) and throttled public endpoints.
+
+### Cache Shape
+
+`delegate-cache.json` is bundled in the package (`@gzeoneth/gov-tracker/delegate-cache.json`). On disk it uses compact keys; `validateDelegateCache()` deserializes into the canonical `DelegateCache` shape. `getDelegateRankInfo()` builds a lazy `Map<address, rank>` keyed by the cache object (WeakMap), so consecutive lookups are O(1) without mutating the cache.
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -949,3 +949,168 @@ writeContract({
   args: [target, value, data, predecessor, salt],
 });
 ```
+
+---
+
+## Voting
+
+### Cast a Vote on a Governor Proposal
+
+```typescript
+import {
+  prepareCastVote,
+  prepareCastVoteWithReason,
+  VOTE_SUPPORT,
+} from "@gzeoneth/gov-tracker";
+
+// Simple vote — governor shorthand avoids address lookup
+const tx = prepareCastVote(proposalId, VOTE_SUPPORT.FOR, "constitutional");
+await signer.sendTransaction(tx);
+
+// Vote with on-chain reason (stored in event data)
+const tx2 = prepareCastVoteWithReason(
+  proposalId,
+  VOTE_SUPPORT.AGAINST,
+  "Parameter too aggressive; prefer staged rollout.",
+  "non-constitutional"
+);
+await signer.sendTransaction(tx2);
+```
+
+`VOTE_SUPPORT`: `AGAINST` (0), `FOR` (1), `ABSTAIN` (2).
+
+### Register as a Contender and Vote in an Election
+
+```typescript
+import { ethers } from "ethers";
+import {
+  prepareContenderRegistration,
+  prepareNomineeElectionVote,
+  prepareMemberElectionVote,
+  NOMINEE_ELECTION_GOVERNOR_ABI,
+  ADDRESSES,
+} from "@gzeoneth/gov-tracker";
+
+// 1. Register as contender (two-phase: sign EIP-712 typed data, then submit)
+// The first argument MUST be the nominee governor's on-chain name() value —
+// it is used as the EIP-712 domain name, so signatures will be rejected if
+// it doesn't match exactly.
+const governor = new ethers.Contract(
+  ADDRESSES.ELECTION_NOMINEE_GOVERNOR,
+  NOMINEE_ELECTION_GOVERNOR_ABI,
+  l2Provider
+);
+const governorName: string = await governor.name();
+
+const { typedData, buildTransaction } = prepareContenderRegistration(
+  governorName,
+  nomineeProposalId
+);
+const signature = await signer._signTypedData(
+  typedData.domain,
+  typedData.types,
+  typedData.message
+);
+await signer.sendTransaction(buildTransaction(signature));
+
+// 2. Vote in nominee phase — directs your ARB toward a contender
+const nomineeVote = prepareNomineeElectionVote(
+  nomineeProposalId,
+  contenderAddress,
+  votesToAllocate, // BigNumber or decimal string
+  "Supporting for technical expertise"
+);
+await signer.sendTransaction(nomineeVote);
+
+// 3. Vote in member phase — ranks final nominees
+const memberVote = prepareMemberElectionVote(memberProposalId, nomineeAddress, votes);
+await signer.sendTransaction(memberVote);
+```
+
+---
+
+## Delegates
+
+### Top Delegates (Sync, No RPC)
+
+```typescript
+import {
+  loadBundledDelegateCache,
+  getTopDelegates,
+  getDelegateCacheStats,
+} from "@gzeoneth/gov-tracker";
+import { ethers } from "ethers";
+
+const cache = loadBundledDelegateCache();
+const stats = getDelegateCacheStats(cache);
+console.log(`Snapshot @ block ${stats.snapshotBlock} — ${stats.totalDelegates} delegates`);
+
+const top10 = getTopDelegates(cache, 10);
+for (const [i, d] of top10.entries()) {
+  const arb = ethers.utils.formatUnits(d.votingPower, 18);
+  console.log(`#${i + 1} ${d.address} — ${Number(arb).toLocaleString()} ARB`);
+}
+```
+
+### Rank Lookup (O(1))
+
+```typescript
+import { loadBundledDelegateCache, getDelegateRankInfo } from "@gzeoneth/gov-tracker";
+
+const cache = loadBundledDelegateCache();
+const info = getDelegateRankInfo(cache, "0x1234...");
+if (info) {
+  console.log(`Rank #${info.rank}, voting power ${info.votingPower} wei`);
+} else {
+  console.log("Address is not a delegate in the current snapshot");
+}
+```
+
+### Find Top Delegates Who Haven't Voted
+
+```typescript
+import { queryDelegatesNotVoted } from "@gzeoneth/gov-tracker";
+
+// Surfaces the largest wallets that still need to vote on an active proposal
+const notVoted = await queryDelegatesNotVoted(
+  l2Provider,
+  proposalId,
+  "constitutional",
+  { limit: 5, maxDelegatesToCheck: 100 }
+);
+for (const d of notVoted) {
+  console.log(`#${d.rank} ${d.address} — ${d.votingPower} wei`);
+}
+```
+
+### Live Voting Power Batch
+
+```typescript
+import { queryDelegateVotingPowers } from "@gzeoneth/gov-tracker";
+
+const addresses = ["0xabc...", "0xdef...", "0x123..."];
+const powers = await queryDelegateVotingPowers(l2Provider, addresses);
+for (const [addr, wei] of powers) {
+  console.log(`${addr}: ${wei} wei`);
+}
+```
+
+### Build or Refresh the Delegate Cache
+
+Use incremental mode in CI; full rebuild only when switching networks or on cache corruption.
+
+```typescript
+import { buildDelegateCache, loadBundledDelegateCache } from "@gzeoneth/gov-tracker";
+import fs from "node:fs/promises";
+
+// Incremental from bundled cache (fast — resumes from snapshotBlock)
+const existing = loadBundledDelegateCache();
+const updated = await buildDelegateCache(l2Provider, {
+  existingCache: existing,
+  onProgress: (pct, block) => process.stdout.write(`\r${pct.toFixed(1)}% — ${block}`),
+});
+
+await fs.writeFile("./delegate-cache.json", JSON.stringify(updated));
+```
+
+CLI equivalent: `npx @gzeoneth/gov-tracker delegates` (incremental) or `--force` (full rebuild from genesis, requires high-throughput RPC).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gzeoneth/gov-tracker",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Lightweight, high-performance library for tracking Arbitrum DAO governance proposal lifecycle stages",
   "license": "Apache-2.0",
   "author": "gzeoneth",

--- a/src/delegates/cache.ts
+++ b/src/delegates/cache.ts
@@ -50,10 +50,6 @@ function getRankMap(cache: DelegateCache): Map<string, number> {
 }
 
 /**
- * Load the bundled delegate cache shipped with the package.
- * Returns the parsed DelegateCache object.
- */
-/**
  * Get the path to the bundled delegate cache shipped with the package.
  * Tries multiple candidate paths to support dist/ and src/ layouts.
  */

--- a/src/delegates/index.ts
+++ b/src/delegates/index.ts
@@ -8,6 +8,7 @@
 // Cache access (sync, no RPC)
 export {
   loadBundledDelegateCache,
+  getBundledDelegateCachePath,
   extractDelegates,
   getDelegateCacheStats,
   validateDelegateCache,

--- a/src/delegates/indexer.ts
+++ b/src/delegates/indexer.ts
@@ -13,8 +13,7 @@
 
 import { ethers } from "ethers";
 import type { DelegateCache, DelegateInfo } from "../types/delegates";
-import { queryWithRetry, getErrorMessage } from "../utils/rpc-utils";
-import { delay } from "../utils/rpc-utils";
+import { queryWithRetry, getErrorMessage, delay } from "../utils/rpc-utils";
 import { compareBigNumbers } from "../utils/chain";
 import { loggers } from "../utils/logger";
 import { erc20VotesInterface } from "../abis";
@@ -26,10 +25,10 @@ import {
   EXCLUDED_DELEGATE_ADDRESSES,
   EVENT_TOPICS,
 } from "../constants";
+import { DELEGATE_CACHE_VERSION } from "./cache";
 
 const log = loggers.delegates;
 
-import { DELEGATE_CACHE_VERSION } from "./cache";
 const DEFAULT_CHUNK_SIZE = 1_000_000;
 const MIN_CHUNK_SIZE = 1_000;
 const DELAY_BETWEEN_CHUNKS = 100;

--- a/src/index.ts
+++ b/src/index.ts
@@ -585,9 +585,12 @@ export type { LoadedWatermarks } from "./tracker/discovery";
 export {
   // Cache access (sync)
   loadBundledDelegateCache,
+  getBundledDelegateCachePath,
   extractDelegates,
   getDelegateCacheStats,
   validateDelegateCache,
+  serializeDelegateCache,
+  DELEGATE_CACHE_VERSION,
   // Query helpers (sync)
   getTopDelegates,
   getDelegateRankInfo,


### PR DESCRIPTION
## [0.5.0] - 2026-04-13

### Added

- **Delegate Indexing & Query module** (`src/delegates/`) - Cache, query, and live lookups for ARB delegates. Upstreams ~900 LOC from `tally-zero` into the SDK.
  - Cache access (sync, no RPC): `loadBundledDelegateCache()`, `extractDelegates()`, `getDelegateCacheStats()`, `validateDelegateCache()` type guard, `serializeDelegateCache()`, `getBundledDelegateCachePath()`, `DELEGATE_CACHE_VERSION`
  - Query helpers (sync): `getTopDelegates(cache, limit?)`, `getDelegateRankInfo(cache, address)` (O(1) rank + voting power via WeakMap), `filterDelegatesByMinPower()`, `filterDelegatesByAddress()`
  - Live queries (async): `queryDelegatesNotVoted(provider, proposalId, governor, options?)` — multicall-batched `hasVoted` checks for top delegates. `queryDelegateVotingPowers(provider, addresses, tokenAddress?)` — multicall-batched `getVotes()`
  - Indexer: `buildDelegateCache(provider, options?)` — adaptive-chunked scan of `DelegateVotesChanged`, halving on RPC log-limit errors and recovering after consecutive successes. Streams events per-chunk to avoid OOM on full genesis builds. Options: `existingCache`, `force`, `startBlock`, `minVotingPower` (default 10 ARB), `tokenAddress`, `onProgress`
  - Types: `DelegateInfo`, `DelegateCache`, `DelegateCacheStats`, `DelegateNotVoted`, `BuildDelegateCacheOptions`, `QueryDelegatesNotVotedOptions`
  - Constants: `DELEGATE_START_BLOCK`, `EXCLUDED_DELEGATE_ADDRESSES`, `DEFAULT_MIN_VOTING_POWER`
  - ERC20Votes ABI additions: `totalSupply()` and `DelegateVotesChanged` event. New `DELEGATE_VOTES_CHANGED` topic in `EVENT_TOPICS`
  - Bundled cache: `data/delegate-cache.json` exported at `@gzeoneth/gov-tracker/delegate-cache.json`
- **CLI: `delegates` subcommand** - `gov-tracker delegates [--force] [--start-block N] [--output path] [--min-power wei] [--token-address 0x...]` builds/updates delegate cache from live RPC. Scripts: `cache:delegates`, `cache:delegates:force`
- **Governance vote preparation** - Prepare-only functions for voting on Core/Treasury Governor proposals:
  - `prepareCastVote(proposalId, support)` - Simple vote (For/Against/Abstain)
  - `prepareCastVoteWithReason(proposalId, support, reason)` - Vote with on-chain reason
  - `prepareCastVoteWithReasonAndParams(proposalId, support, reason, params)` - Vote with custom params
  - `VOTE_SUPPORT` enum: `AGAINST` (0), `FOR` (1), `ABSTAIN` (2)
  - Governor shorthand: pass `"constitutional"` or `"non-constitutional"` instead of addresses
- **Operation ID hashing (public)** - `hashOperation()` and `hashOperationBatch()` now exported from public API (previously internal-only)
- **Governor ABI additions** - Added `castVote`, `castVoteWithReason`, `castVoteWithReasonAndParams`, `castVoteBySig`, `getVotes`, `hasVoted`, `ProposalCreated` event to `GOVERNOR_ABI`
- **ERC20Votes ABI read helpers** - Added `getVotes(address)` (current voting power without block number) and `delegates(address)` to `ERC20_VOTES_ABI`
- **Election write actions** - Prepare-only functions for election participation (contender registration, vote casting):
  - `encodeElectionVoteParams()` / `decodeElectionVoteParams()` - ABI encode/decode `(address, uint256)` vote params
  - `getAddContenderTypedData()` - Build EIP-712 typed data for contender registration signing
  - `prepareAddContender()` - Prepare `addContender(proposalId, signature)` transaction
  - `prepareContenderRegistration()` - Two-phase API: returns typed data for signing + `buildTransaction(signature)` for submission
  - `prepareNomineeElectionVote()` / `prepareMemberElectionVote()` - Prepare `castVoteWithReasonAndParams` transactions
  - Types: `AddContenderTypedData`, `PreparedContenderRegistration`
- **ABI exports** - All governance ABIs now publicly exported in two formats: human-readable `as const` (`GOVERNOR_ABI`, `TIMELOCK_ABI`, etc.) for ethers v5 and abitype, and JSON `as const` (`governorAbi`, `timelockAbi`, etc.) for wagmi/viem `useReadContract`/`useWriteContract` type inference. Curated read/write subsets (`governorReadAbi`, `governorWriteAbi`, `nomineeElectionGovernorReadAbi`, etc.) for large ABIs that exceed viem's type inference limits
- **Standalone timelock execution** - `prepareExecuteTimelock(timelockAddress, operationId, salt, provider)` prepares a timelock `execute`/`executeBatch` transaction without requiring the full tracking pipeline. Auto-detects single vs batch operations from on-chain `CallScheduled` events
- **Sync timelock calldata prep** - `prepareTimelockExecuteCalldata()` and `prepareTimelockBatchCalldata()` encode timelock execution calldata without a provider, for consumers that already have operation params from tracking
- **Proposal state constants** - `PROPOSAL_STATE` (numeric enum: `PENDING=0` through `EXECUTED=7`), `PROPOSAL_STATE_MAP` (PascalCase reverse lookup), and `PROPOSAL_STATE_LABEL` (lowercase reverse lookup) now exported for consumers tracking proposal lifecycle
- **ARB_TOKEN address** - `ADDRESSES.ARB_TOKEN` (`0x912C...6548`) exported — the last governance address consumers had to hardcode locally
- **RPC utilities (public)** - `queryWithRetry`, `isPermanentError`, `isRetryableError`, `getErrorMessage` now exported for consumers building retry logic around the SDK
- **Read helpers for wagmi** - Pure functions returning `{ address, abi, functionName, args }` for `useReadContract` / `useReadContracts` (multicall). Abstracts contract knowledge entirely:
  - Governor: `readProposalState`, `readProposalVotes`, `readProposalSnapshot`, `readProposalDeadline`, `readQuorum`, `readGetVotes`, `readHasVoted`
  - Token: `readVotingPower` (at block), `readCurrentVotingPower` (live), `readDelegate`
  - Election: `readNomineeElectionState`, `readMemberElectionState`, `readElectionCount`, `readVotesUsed`, `readIsContender`, `readGovernorName`
- **Event query API** - `queryProposalCreatedEvents(provider, governorAddress, fromBlock, toBlock?)` returns `ProposalData[]` without the full tracking pipeline
- **ProposalStateValue type** - Numeric union type (`0 | 1 | ... | 7`) derived from `PROPOSAL_STATE`, with `isProposalState()` type guard for exhaustive switch checking
- **Election deployment config** - `ElectionConfig` type bundles `nomineeGovernorAddress`, `memberGovernorAddress`, `tokenAddress`, and `chainId` for testnet/fork deployments. `MAINNET_ELECTION_CONFIG` preset for Arbitrum One mainnet
- **`getElectionStatus(l2Provider, electionIndex, config?)`** — Returns full `ElectionProposalStatus` (phase, cohort, compliantNomineeCount, vettingDeadline, canProceedToMemberPhase, canExecuteMember) in one call. Fetches election-specific cohort via `electionIndexToCohort`
- **`getAllElectionStatuses(l2Provider, config?)`** — Batch-fetch status for all elections in parallel
- **`determineElectionPhase` public export** — Pure function for state-to-phase mapping now exported at top level (was only re-exported from election module)
- **BigNumber sorting** - `compareBigNumbers` exported for sorting `CallScheduledData` arrays by index
- **Public provider access** - `l2Provider`, `l1Provider`, and `novaProvider` are now publicly accessible as readonly properties on `ProposalStageTracker`
- **Stage merging utilities** - Helpers for combining stages from multiple checkpoints into a unified timeline:
  - `mergeStages(primary, secondary)` - Merge stages with intelligent deduplication (prefers higher status)
  - `normalizeTimeline(stages)` - Sort stages in canonical pipeline order
  - `splitStages(stages)` - Split into parent and timelock stages (re-exported for convenience)
- **Simulation extraction by action index** - `extractSimulationsByActionIndex(decodedActions, chain)` returns `IndexedSimulation[]` with `actionIndex` tracking for UI builders
- **Tenderly payload builders** - Dependency-free utilities for building Tenderly API requests:
  - `buildTenderlySimRequest(simulation, overrides?)` - Build simulate endpoint payload
  - `buildTenderlyEncodeStatesRequest(simulations)` - Build encode-states payload for timelock storage overrides
- **RPC URL support** - `TrackerOptions` now accepts RPC URLs as strings in addition to Provider objects. `l1Provider`, `l2Provider`, and `novaProvider` all accept either `ethers.providers.Provider` or a URL string
- **Bundled cache extraction utilities** - Type-safe helpers for extracting data from bundled cache JSON:
  - `extractProposals()` - Extract proposal metadata from cache
  - `extractTimelockOps()` - Extract timelock operation metadata
  - `extractElections()` - Extract election metadata
  - `extractOperationIds()` - Get Map of proposalId → operationId
  - `getWatermarksFromCache()` - Get discovery watermarks from cache
  - `getVotingDataFromStages()` - Extract typed vote data from stages
  - `extractTimelockLinkFromStages()` - Extract TimelockLink from completed stages
- **Stage metadata helpers** - `getAllStageMetadata()` returns a memoized `Record<StageType, StageMetadata>`; `ALL_STAGE_TYPES` constant exposes stage types in pipeline order
- **Checkpoint re-tracking** - `trimFromStage(checkpoint, stageIndex)` trims stages for re-tracking scenarios
- **Lifecycle phase helper** - `getLifecyclePhase(stages)` returns a human-readable `LifecyclePhase`: `voting`, `queued`, `l2_delay`, `bridging`, `l1_delay`, `finalizing`, `executed`, `failed`, `unknown`
- **Watermark access** - `loadWatermarks()` / `LoadedWatermarks` type expose discovery watermarks from cache
- **Error utility** - `getErrorMessage()` shared error-message extraction utility now exported

### Fixed

- **PreparedTransaction typed hex fields** - `to` and `data` are now typed as `` `0x${string}` `` instead of `string`, eliminating consumer-side casts for wagmi/viem integration
- **AddContenderTypedData wagmi compatibility** - `message.proposalId` is now `bigint` (was `string`), matching wagmi's `useSignTypedData` expectation. `domain.verifyingContract` is now `` `0x${string}` ``
- **AddContenderTypedData compatibility** - `types.AddContenderMessage` field changed from `readonly` tuple with literal types to `Array<{ name: string; type: string }>`, fixing assignability errors with ethers v5 `signer._signTypedData()` and ethers v6 `signer.signTypedData()`
- **PreparedTransaction chain/chainId consistency** - Write-action functions that accept `chainId` now derive `chain` via `chainIdToChain(chainId)` instead of hardcoding `"arb1"`, preventing misrouted transactions when targeting non-42161 deployments
- **Election phase priority** - `determineElectionPhase` returned `VETTING_PERIOD` instead of `NOMINEE_SELECTION` when the nominee proposal was `Active` with the vetting flag set. The vetting (compliance check) phase only applies after nominee voting ends (`Succeeded`), not during active voting. Correct order: Contender Submission → Nominee Selection → Compliance Check → Member Election
- **BigNumber overflow** - Use `.gt()`/`.lt()` instead of `.toNumber()` for CallScheduled index sorting
- **Discovery errors** - Provider errors during watermark verification now return `isValid: false`
- **Decode errors** - `decodeRetryableTicket()`, `prepareTimelockSimulation()`, `convertScheduleToExecute()` return null on failure instead of throwing
- **CLI validation** - NaN-safe parsing for gas settings and election indices
- **Bounds checks** - Safe array access for `log.topics`, multicall results, and TUI components
- **Timeout cleanup** - Fixed `clearTimeout()` not called in error paths for API fetch operations

### Changed

- **Documentation** - Removed outdated `trackFromGovernor()`/`trackFromTimelock()` API references; fixed test command names
- **Performance** - Parallelize cache operations throughout (checkpoint loading, election tracking, deduplication, SC nonce queries)
- **Performance** - Fetch gas price once per batch in `calculateBatchRetryableValues()`
- **Performance** - `--force` clears cache at session start instead of bypassing mid-session
- **Robustness** - `Promise.allSettled` for watermark verification; graceful fallback for Arbitrum network detection
- **Type safety** - `RetryableSimulationData.l2Chain` changed to `L2Chain | "unknown"`
- **Code consolidation** - Time constants centralized in `TIMING` object; address comparison uses shared utilities
- **Scripts** - `cache:generate` is now incremental by default; `cache:generate:force` rebuilds from scratch (was a single `--force` script before). Refreshed bundled proposal cache

### Refactored

- Consolidated duplicate code: gas error detection (`isGasEstimationError`), markdown title extraction, SC nonce helpers, fromBlock validation
- Replaced type casts with discriminated union narrowing in TUI components
- Single-pass nominee filtering in election details

### Removed

- Internal TUI utilities `getAllFoldableKeys` and `toggleFoldKey` from public exports
- Unused `erc20VotesInterface` export (only the ABI array `ERC20_VOTES_ABI` is needed)
